### PR TITLE
Reversed the check for an available BTRFS file system.

### DIFF
--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -203,7 +203,7 @@ log info "Doing snapshots of $fs_list"
 
 for i in $fs_list
 do
-    echo "$btrfs_list" | grep -q "$i"
+    echo "$btrfs_list" | grep -F -f - -q <(echo ${i})
     if [ $? -ne 0 ] ; then
         log err "It appears that $i is not a BTRFS filesystem"
         exit 135


### PR DESCRIPTION
I'm using BTRFS formatted USB disk for backup purposes, with multiple subvolumes for different purposes. `btrfs-auto-snapshot` is used to maintain history for each individual purpose. The default implementation doesn't support that use-case because it checks if a given path is a known mounted BTRFS file system. That is not the case, because the given path is a subvolume and that is not mounted by default, but only it's parent.

To support my use-case, the check needs to be reversed: Does the given path contain a known BTRFS file system? If so it's a subvolume most likely. In theory this could even be enhanced to check the given path against all known subvolumes for some BTRFS file system, e.g. to prevent accidently providing non-subvolume dirs or alike. Though, doesn't seem to be that important for me.

The reversed check seems to be the only thing I needed to change to support my use-case and in my opinion makes `btrfs-auto-snapshot` more flexible. Using different subvolumes for different purposes is pretty common with BTRFS.

```bash
bash-4.3# grep btrfs /proc/mounts | awk '{print $2}'
/volume1
/volumeUSB1/usbshare
bash-4.3#
```

My subvolume is in `/volumeUSB1/usbshare/some_child`. That is clearly not contained in the above output. Though, the second line of the above output is contained in my given path, hence the changed search for GREP. That provides everythign we need already:

> -F, --fixed-strings
Interpret PATTERN as a list of fixed strings, separated by newlines, any of which is to be matched. (-F is specified by POSIX .)

https://linux.die.net/man/1/grep