### PR TITLE
Calculate all BTRFS subvolumes when using //.

### DIFF
--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -223,7 +223,7 @@ if [ ! -z "${keep}" ] ; then
 
     for i in $fs_list
     do
-        btrfs subvolume list -g --sort=gen $i | \
+        btrfs subvolume list -g -s --sort=gen $i | \
         sort -r -n -k 4 | awk '{print $NF}' | while read j
         do
             if [ -z "${j#$snapglob}" ] ; then

--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -322,7 +322,8 @@ if [ ! -z "${keep}" ] ; then
 
     for i in $fs_list
     do
-        snaps="$(btrfs subvolume list -g -o -s --sort=gen "${i}")"
+        fs_keep="${keep}"
+	snaps="$(btrfs subvolume list -g -o -s --sort=gen "${i}")"
 	paths="$(echo "${snaps}" | sort -r -n -k 4 | awk '{print $NF}')"
 	paths="$(echo "${paths}" | sed  -r 's!^[^/]+/.btrfs/!.btrfs/!')"
 
@@ -332,8 +333,8 @@ if [ ! -z "${keep}" ] ; then
                 continue
             fi
             
-	    keep=$(( $keep - 1 ))
-            if [ $keep -lt 0 ] ; then
+	    fs_keep=$(( ${fs_keep} - 1 ))
+            if [ ${fs_keep} -lt 0 ] ; then
                 log notice $( ${dry_run} btrfs subvolume \
                     delete -c ${i}/${j} )
             fi

--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -111,29 +111,29 @@ log()
 #
 argsp_stdin_to_array()
 {
-  local -r stdin="$(cat '/dev/stdin')"
-  local -a ret_val=()
+    local -r stdin="$(cat '/dev/stdin')"
+    local -a ret_val=()
 
-  while IFS= read -r line; do
-    local is_blank="$(  echo "${line}" | grep --count -e '^[[:space:]]*$')"
-    local is_comment="$(echo "${line}" | grep --count -e '^#')"
-    local is_empty="$(  echo "${line}" | grep --count -e '^$')"
+    while IFS= read -r line; do
+        local is_blank="$(  echo "${line}" | grep --count -e '^[[:space:]]*$')"
+        local is_comment="$(echo "${line}" | grep --count -e '^#')"
+        local is_empty="$(  echo "${line}" | grep --count -e '^$')"
 
-    if [ "${is_blank}" = '1' ] || [ "${is_comment}" = '1' ] || [ "${is_empty}" = '1' ]
+        if [ "${is_blank}" = '1' ] || [ "${is_comment}" = '1' ] || [ "${is_empty}" = '1' ]
+        then
+            continue
+        fi
+
+        ret_val+=(${line})
+    done <<< "${stdin}"
+
+    if [ ${#ret_val[@]} -eq 0 ]
     then
-      continue
+        echo 'No arguments given using STDIN.' >&2
+        exit ${ERR_STDIN_EMPTY}
     fi
 
-    ret_val+=(${line})
-  done <<< "${stdin}"
-
-  if [ ${#ret_val[@]} -eq 0 ]
-  then
-    echo 'No arguments given using STDIN.' >&2
-    exit ${ERR_STDIN_EMPTY}
-  fi
-
-  declare -p ret_val | sed -e 's/^declare -a [^=]*=//'
+    declare -p ret_val | sed -e 's/^declare -a [^=]*=//'
 }
 
 ##

--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -29,7 +29,14 @@ verbose=''
 quiet=''
 writeable='-r'
 
-ARGSP_ERR_STDIN_EMPTY=1
+ERR_SUCCESS=0
+ERR_STDIN_EMPTY=1
+ERR_GETOPT_FAILED=128
+ERR_KEEP_NEGATIVE=129
+ERR_PREFIX_WRONG=130
+ERR_FS_MISSING=133
+ERR_FS_SLASHIES=134
+ERR_FS_NO_BTRFS=135
 
 usage()
 {
@@ -123,7 +130,7 @@ argsp_stdin_to_array()
   if [ ${#ret_val[@]} -eq 0 ]
   then
     echo 'No arguments given using STDIN.' >&2
-    exit ${ARGSP_ERR_STDIN_EMPTY}
+    exit ${ERR_STDIN_EMPTY}
   fi
 
   declare -p ret_val | sed -e 's/^declare -a [^=]*=//'
@@ -182,7 +189,7 @@ getopt=$(getopt \
     --longoptions=syslog,writeable \
     --options=d,g,h,k:,l:,n,p:,q,v,w \
     -- "$@" ) \
-    || exit 128
+    || exit ${ERR_GETOPT_FAILED}
 
 eval set -- "$getopt"
 
@@ -201,12 +208,12 @@ do
             ;;
         (-h|--help)
             usage
-            exit 0
+            exit ${ERR_SUCCESS}
             ;;
         (-k|--keep)
             if ! test $2 -gt 0 2>/dev/null; then
                 log error "The $1 parameter must be a positive integer"
-                exit 129
+                exit ${ERR_KEEP_NEGATIVE}
             fi
             keep=$2
             shift 2
@@ -228,7 +235,7 @@ do
                 case $prefix in
                     ([![:alnum:]_.:\ -]*)
                         log error "The $1 parameter must be alphanumeric"
-                        exit 130
+                        exit ${ERR_PREFIX_WRONG}
                         ;;
                 esac
                 prefix="${prefix#?}"
@@ -260,7 +267,7 @@ done
 
 if [ $# -eq 0 ] ; then
     log error "The filesystem argument list is empty"
-    exit 133
+    exit ${ERR_FS_MISSING}
 fi
 
 # count the number of times '//' appears on the command line
@@ -272,7 +279,7 @@ done
 
 if [ $# -gt 1 -a $slashies -gt 0 ] ; then
     log error "The // must be the only argument if it is given"
-    exit 134
+    exit ${ERR_FS_SLASHIES}
 fi
 
 snapname=${prefix}_${label}-$(date +%F-%H%M)
@@ -294,7 +301,7 @@ do
     printf "%s\n" "${btrfs_list[@]}" | grep -F -f - -q <(echo ${i})
     if [ $? -ne 0 ] ; then
         log err "It appears that '${i}' is not a BTRFS filesystem!"
-        exit 135
+        exit ${ERR_FS_NO_BTRFS}
     fi
 
     if [ ! -d "${i}/.btrfs" ] ; then

--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -298,7 +298,7 @@ log info "Doing snapshots of $fs_list"
 
 for i in $fs_list
 do
-    printf "%s\n" "${btrfs_list[@]}" | grep -F -f - -q <(echo ${i})
+    printf "%s\n" "${btrfs_list[@]}" | grep -F -f - -q -x <(echo ${i})
     if [ $? -ne 0 ] ; then
         log err "It appears that '${i}' is not a BTRFS filesystem!"
         exit ${ERR_FS_NO_BTRFS}

--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -29,6 +29,8 @@ verbose=''
 quiet=''
 writeable='-r'
 
+ARGSP_ERR_STDIN_EMPTY=1
+
 usage()
 {
     echo "Usage: $0 [options] [-l label] <'//' | name [name...]>
@@ -42,7 +44,7 @@ usage()
     -q, --quiet         Suppress warning and notices on STDOUT
     -v, --verbose       Print info messages
     -w, --writeable     Create writeable snapshots instead of read-only
-    name            Filesystem name(s), or '//' for all filesystems
+    name                Filesystem name(s), or '//' for all filesystems
 "
 }
 
@@ -87,6 +89,91 @@ log()
             echo $* 1>&2
             ;;
     esac
+}
+
+##
+# {@code STDIN} can only be consumed once, so read and return it here for later processing.
+#
+# The current approach is to have one argument per line, so we are iterating all of those already,
+# remove empty lines, comments etc. and are able to check if anything was read at all in the end. If
+# not, this is most likely an error, as it doesn't make much sense to explicitly call us, so the
+# script is aborted.
+#
+# @return {@code [0]="..." [1]="..." [...]}
+# @see <a href="https://stackoverflow.com/a/16843375/2055163">How to return an array in bash without using globals?</a>
+#
+argsp_stdin_to_array()
+{
+  local -r stdin="$(cat '/dev/stdin')"
+  local -a ret_val=()
+
+  while IFS= read -r line; do
+    local is_blank="$(  echo "${line}" | grep --count -e '^[[:space:]]*$')"
+    local is_comment="$(echo "${line}" | grep --count -e '^#')"
+    local is_empty="$(  echo "${line}" | grep --count -e '^$')"
+
+    if [ "${is_blank}" = '1' ] || [ "${is_comment}" = '1' ] || [ "${is_empty}" = '1' ]
+    then
+      continue
+    fi
+
+    ret_val+=(${line})
+  done <<< "${stdin}"
+
+  if [ ${#ret_val[@]} -eq 0 ]
+  then
+    echo 'No arguments given using STDIN.' >&2
+    exit ${ARGSP_ERR_STDIN_EMPTY}
+  fi
+
+  declare -p ret_val | sed -e 's/^declare -a [^=]*=//'
+}
+
+##
+# Calculate all BTRFS subvolumes based on all mounted BTRFS file systems.
+#
+# "zfs-auto-snapshot" is not only able to snapshot all pools, but as well all individual datasets
+# when using "//" as path. This function actually allows the same approach by not only looking at
+# mountpounts for BTRFS file systems, but their contained subvolumes as well. By default, each and
+# every subvolume simply gets a ".btrfs" directory to take snapshots and snapshots themself are of
+# course excluded here.
+#
+# @stdin  BTRFS file systems of interest, one per line.
+# @return All subvolumes, one per line.
+#
+btrfs_subvols_calc()
+{
+    local -a ret_val=()
+    local -r array_txt="$(argsp_stdin_to_array)"
+    eval "declare -a mps=${array_txt}"
+
+    for mp in "${mps[@]}"
+    do
+        # The mountpoint itself obviously is a subvolume of interest as well already.
+        ret_val+=(${mp})
+
+        local subvols="$(btrfs subvolume list "${mp}" | awk '{print $9}')"
+
+        # Subvolumes seem to have no parent UUID, while snapshots are "readonly" most likely. So
+	# check for these attributes, which seems easier than to exclude all currently available
+        # snapshots by their paths. That output doesn't include leading slashes, their common
+	# directory might change its name etc.
+        while IFS= read -r subvol
+        do
+            local abs_path="$(echo ${mp}/${subvol} | sed -r 's!^//!/!')"
+            local show="$(btrfs subvolume show "${abs_path}")"
+	    local sp='[[:space:]]+'
+            local no_parent_uuid="$(echo "${show}" | grep --count -E "^${sp}Parent UUID:${sp}-$")"
+            local is_read_only="$(  echo "${show}" | grep --count -E "^${sp}Flags:${sp}readonly$")"
+
+            if [ "${no_parent_uuid}" = '1' ] && [ "${is_read_only}" = '0' ]
+            then
+                ret_val+=(${abs_path})
+            fi
+        done <<< "${subvols}"
+    done
+
+    declare -p ret_val | sed -e 's/^declare -a [^=]*=//'
 }
 
 getopt=$(getopt \
@@ -191,10 +278,11 @@ fi
 snapname=${prefix}_${label}-$(date +%F-%H%M)
 snapglob=".btrfs/${prefix}_${label}????????????????"
 
-btrfs_list=$(grep btrfs /proc/mounts | awk '{print $2}')
+btrfs_list=$(grep btrfs /proc/mounts | awk '{print $2}' | btrfs_subvols_calc)
+eval "declare -a btrfs_list=${btrfs_list}"
 
 if [ "$1" = '//' ] ; then
-    fs_list=$btrfs_list
+    fs_list="${btrfs_list[@]}"
 else
     fs_list="$@"
 fi
@@ -203,19 +291,23 @@ log info "Doing snapshots of $fs_list"
 
 for i in $fs_list
 do
-    echo "$btrfs_list" | grep -F -f - -q <(echo ${i})
+    printf "%s\n" "${btrfs_list[@]}" | grep -F -f - -q <(echo ${i})
     if [ $? -ne 0 ] ; then
-        log err "It appears that $i is not a BTRFS filesystem"
+        log err "It appears that '${i}' is not a BTRFS filesystem!"
         exit 135
     fi
 
     if [ ! -d "${i}/.btrfs" ] ; then
-        ${dry_run} mkdir ${i}/.btrfs
+        ${dry_run} mkdir "${i}/.btrfs"
     fi
 
+    # TODO Creating snapshots too frequently so that names overlap with an existing one, result in
+    # some error message about read-only file system, not mentioning the actual snapshot itself at
+    # all. Is bit difficult to understand when happening especially during tests, so might check if
+    # the desired snapshot exists already.
     log notice $( ${dry_run} btrfs subvolume snapshot \
-        ${writeable} ${i} \
-        ${i}/.btrfs/${snapname} )
+        ${writeable} "${i}" \
+        "${i%/}/.btrfs/${snapname}" )
 done
 
 if [ ! -z "${keep}" ] ; then
@@ -223,17 +315,22 @@ if [ ! -z "${keep}" ] ; then
 
     for i in $fs_list
     do
-        btrfs subvolume list -g -s --sort=gen $i | \
-        sort -r -n -k 4 | awk '{print $NF}' | while read j
+        snaps="$(btrfs subvolume list -g -o -s --sort=gen "${i}")"
+	paths="$(echo "${snaps}" | sort -r -n -k 4 | awk '{print $NF}')"
+	paths="$(echo "${paths}" | sed  -r 's!^[^/]+/.btrfs/!.btrfs/!')"
+
+	while IFS= read j
         do
-            if [ -z "${j#$snapglob}" ] ; then
-                keep=$(( $keep - 1 ))
-                if [ $keep -lt 0 ] ; then
-                    log notice $( ${dry_run} btrfs subvolume \
-                        delete -c ${i}/${j} )
-                fi
+            if [ ! -z "${j#$snapglob}" ] ; then
+                continue
             fi
-        done
+            
+	    keep=$(( $keep - 1 ))
+            if [ $keep -lt 0 ] ; then
+                log notice $( ${dry_run} btrfs subvolume \
+                    delete -c ${i}/${j} )
+            fi
+	done <<< "${paths}"
     done
 fi
 


### PR DESCRIPTION
Maybe I'm missing something, but it seems to me that the script only works with the "root" subvolume of each BTRFS mounted file system. Though, I have the use-case of using multiple different subvolumes within the same file system and would like to keep snapshots for all of them automatically. From my understanding, this is exactly how `//` works in my systems using ZFS: Each dataset gets its own snapshots.

Therefore I (hopefully :-)) enhanced the script to calculate all subvolumes of all BTRFS file systems, ignore existing snapshots being subvolumes as well, and create snapshots for all of those subvolumes. This included minor changes to what has been merged in #4, how `$keep` is used etc. Things seem to work pretty well for where I deployed the new code.

While the change is somewhat incompatible with the former behaviour, I didn't introduce a new option by purpose. I had the feeling you want to follow `zfs-auto-snapshot` and it's default behaviour and its doing exactly the same. If someone needs something different, it shouldn't be too difficult to implement such switch in future.