### PR TITLE
Calculate all BTRFS subvolumes when using // and use more functions for better readability.

### DIFF
--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+##
 # btrfs-auto-snapshot for Linux
 # Automatically create, rotate, and destroy periodic BTRFS snapshots.
 # Copyright 2014 Doug Hunley <doug.hunley@gmail.com>
@@ -20,6 +21,7 @@
 
 ERR_SUCCESS=0
 ERR_STDIN_EMPTY=1
+ERR_MISSING_SYS_REQS=2
 ERR_GETOPT_FAILED=128
 ERR_KEEP_NEGATIVE=129
 ERR_PREFIX_WRONG=130
@@ -40,6 +42,19 @@ use_syslog=''
 verbose=''
 quiet=''
 writeable='-r'
+
+##
+# Check for available necessary system requirements, like a current enough bash and stuff.
+#
+check_sys_reqs()
+{
+    unset assoc
+    if ! declare -A assoc 2> /dev/null
+    then
+        echo "Associative arrays not supported! At least BASH 4 needed."
+        exit ${ERR_MISSING_SYS_REQS}
+    fi
+}
 
 usage()
 {
@@ -398,6 +413,7 @@ btrfs_snaps_rm_if()
     done
 }
 
+check_sys_reqs
 getopt=$(getopt \
     --longoptions=debug,help,keep:,label: \
     --longoptions=dry-run,prefix:,quiet,verbose \

--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -323,6 +323,81 @@ btrfs_subvols_calc()
     declare -p ret_val | sed -e 's/^declare -a [^=]*=//'
 }
 
+##
+# Create snapshots using the paths
+#
+# @param[in] The paths to work with.
+#
+btrfs_snaps_do()
+{
+    local -r fs_list="${1:?No paths given.}"
+
+    log info "Doing snapshots of $fs_list"
+
+    for i in $fs_list
+    do
+        printf "%s\n" "${btrfs_list[@]}" | grep -F -f - -q -x <(echo ${i})
+        if [ $? -ne 0 ]
+	then
+            log err "It appears that '${i}' is not a BTRFS filesystem!"
+            exit ${ERR_FS_NO_BTRFS}
+        fi
+
+        if [ ! -d "${i}/.btrfs" ]
+	then
+            ${dry_run} mkdir "${i}/.btrfs"
+        fi
+
+        # TODO Creating snapshots too frequently so that names overlap with an existing one, result
+        # in some error message about read-only file system, not mentioning the actual snapshot
+	# itself at all. Is bit difficult to understand when happening especially during tests, so
+        # might check if the desired snapshot exists already.
+        log notice $( ${dry_run} btrfs subvolume snapshot \
+            ${writeable} "${i}" \
+            "${i%/}/.btrfs/${snapname}" )
+    done
+}
+
+##
+# Cleanup snapshots depending on how many to keep, if to cleanup at all.
+#
+# @param[in] The paths to work with.
+#
+btrfs_snaps_rm_if()
+{
+    if [ -z "${keep}" ]
+    then
+        return
+    fi
+
+    local -r fs_list="${1:?No paths given.}"
+
+    log info "Destroying all but the newest ${keep} snapshots"
+
+    for i in $fs_list
+    do
+        fs_keep="${keep}"
+        snaps="$(btrfs subvolume list -g -o -s --sort=gen "${i}")"
+        paths="$(echo "${snaps}" | sort -r -n -k 4 | awk '{print $NF}')"
+        paths="$(echo "${paths}" | sed  -r 's!^[^/]+/.btrfs/!.btrfs/!')"
+
+        while IFS= read -r j
+        do
+            if [ ! -z "${j#$snapglob}" ]
+	    then
+                continue
+            fi
+
+            fs_keep=$(( ${fs_keep} - 1 ))
+            if [ ${fs_keep} -lt 0 ]
+	    then
+                log notice $( ${dry_run} btrfs subvolume \
+                    delete -c ${i}/${j} )
+            fi
+        done <<< "${paths}"
+    done
+}
+
 getopt=$(getopt \
     --longoptions=debug,help,keep:,label: \
     --longoptions=dry-run,prefix:,quiet,verbose \
@@ -358,52 +433,7 @@ else
     fs_list="${cmdline[paths]}"
 fi
 
-log info "Doing snapshots of $fs_list"
-
-for i in $fs_list
-do
-    printf "%s\n" "${btrfs_list[@]}" | grep -F -f - -q -x <(echo ${i})
-    if [ $? -ne 0 ] ; then
-        log err "It appears that '${i}' is not a BTRFS filesystem!"
-        exit ${ERR_FS_NO_BTRFS}
-    fi
-
-    if [ ! -d "${i}/.btrfs" ] ; then
-        ${dry_run} mkdir "${i}/.btrfs"
-    fi
-
-    # TODO Creating snapshots too frequently so that names overlap with an existing one, result in
-    # some error message about read-only file system, not mentioning the actual snapshot itself at
-    # all. Is bit difficult to understand when happening especially during tests, so might check if
-    # the desired snapshot exists already.
-    log notice $( ${dry_run} btrfs subvolume snapshot \
-        ${writeable} "${i}" \
-        "${i%/}/.btrfs/${snapname}" )
-done
-
-if [ ! -z "${keep}" ] ; then
-    log info "Destroying all but the newest ${keep} snapshots"
-
-    for i in $fs_list
-    do
-        fs_keep="${keep}"
-	snaps="$(btrfs subvolume list -g -o -s --sort=gen "${i}")"
-	paths="$(echo "${snaps}" | sort -r -n -k 4 | awk '{print $NF}')"
-	paths="$(echo "${paths}" | sed  -r 's!^[^/]+/.btrfs/!.btrfs/!')"
-
-	while IFS= read -r j
-        do
-            if [ ! -z "${j#$snapglob}" ] ; then
-                continue
-            fi
-            
-	    fs_keep=$(( ${fs_keep} - 1 ))
-            if [ ${fs_keep} -lt 0 ] ; then
-                log notice $( ${dry_run} btrfs subvolume \
-                    delete -c ${i}/${j} )
-            fi
-	done <<< "${paths}"
-    done
-fi
+btrfs_snaps_do    "${fs_list}"
+btrfs_snaps_rm_if "${fs_list}"
 
 # vim: set expandtab:ts=4:sw=4

--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -223,7 +223,7 @@ if [ ! -z "${keep}" ] ; then
 
     for i in $fs_list
     do
-        btrfs subvolume list -g --sort=gen $i | \
+        btrfs subvolume list -g -s --sort=gen $i | \
         sort -r -n -k 4 | awk '{print $NF}' | while read j
         do
             if [ -z "${j#$snapglob}" ] ; then

--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -322,7 +322,8 @@ if [ ! -z "${keep}" ] ; then
 
     for i in $fs_list
     do
-        snaps="$(btrfs subvolume list -g -o -s --sort=gen "${i}")"
+        fs_keep="${keep}"
+	snaps="$(btrfs subvolume list -g -o -s --sort=gen "${i}")"
 	paths="$(echo "${snaps}" | sort -r -n -k 4 | awk '{print $NF}')"
 	paths="$(echo "${paths}" | sed  -r 's!^[^/]+/.btrfs/!.btrfs/!')"
 
@@ -332,8 +333,8 @@ if [ ! -z "${keep}" ] ; then
                 continue
             fi
             
-	    keep=$(( $keep - 1 ))
-            if [ $keep -lt 0 ] ; then
+	    fs_keep=$(( ${fs_keep} - 1 ))
+            if [ ${fs_keep} -lt 0 ] ; then
                 log notice $( ${dry_run} btrfs subvolume \
                     delete -c ${i}/${j} )
             fi

--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -111,29 +111,29 @@ log()
 #
 argsp_stdin_to_array()
 {
-  local -r stdin="$(cat '/dev/stdin')"
-  local -a ret_val=()
+    local -r stdin="$(cat '/dev/stdin')"
+    local -a ret_val=()
 
-  while IFS= read -r line; do
-    local is_blank="$(  echo "${line}" | grep --count -e '^[[:space:]]*$')"
-    local is_comment="$(echo "${line}" | grep --count -e '^#')"
-    local is_empty="$(  echo "${line}" | grep --count -e '^$')"
+    while IFS= read -r line; do
+        local is_blank="$(  echo "${line}" | grep --count -e '^[[:space:]]*$')"
+        local is_comment="$(echo "${line}" | grep --count -e '^#')"
+        local is_empty="$(  echo "${line}" | grep --count -e '^$')"
 
-    if [ "${is_blank}" = '1' ] || [ "${is_comment}" = '1' ] || [ "${is_empty}" = '1' ]
+        if [ "${is_blank}" = '1' ] || [ "${is_comment}" = '1' ] || [ "${is_empty}" = '1' ]
+        then
+            continue
+        fi
+
+        ret_val+=(${line})
+    done <<< "${stdin}"
+
+    if [ ${#ret_val[@]} -eq 0 ]
     then
-      continue
+        echo 'No arguments given using STDIN.' >&2
+        exit ${ERR_STDIN_EMPTY}
     fi
 
-    ret_val+=(${line})
-  done <<< "${stdin}"
-
-  if [ ${#ret_val[@]} -eq 0 ]
-  then
-    echo 'No arguments given using STDIN.' >&2
-    exit ${ERR_STDIN_EMPTY}
-  fi
-
-  declare -p ret_val | sed -e 's/^declare -a [^=]*=//'
+    declare -p ret_val | sed -e 's/^declare -a [^=]*=//'
 }
 
 ##

--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -29,7 +29,14 @@ verbose=''
 quiet=''
 writeable='-r'
 
-ARGSP_ERR_STDIN_EMPTY=1
+ERR_SUCCESS=0
+ERR_STDIN_EMPTY=1
+ERR_GETOPT_FAILED=128
+ERR_KEEP_NEGATIVE=129
+ERR_PREFIX_WRONG=130
+ERR_FS_MISSING=133
+ERR_FS_SLASHIES=134
+ERR_FS_NO_BTRFS=135
 
 usage()
 {
@@ -123,7 +130,7 @@ argsp_stdin_to_array()
   if [ ${#ret_val[@]} -eq 0 ]
   then
     echo 'No arguments given using STDIN.' >&2
-    exit ${ARGSP_ERR_STDIN_EMPTY}
+    exit ${ERR_STDIN_EMPTY}
   fi
 
   declare -p ret_val | sed -e 's/^declare -a [^=]*=//'
@@ -182,7 +189,7 @@ getopt=$(getopt \
     --longoptions=syslog,writeable \
     --options=d,g,h,k:,l:,n,p:,q,v,w \
     -- "$@" ) \
-    || exit 128
+    || exit ${ERR_GETOPT_FAILED}
 
 eval set -- "$getopt"
 
@@ -201,12 +208,12 @@ do
             ;;
         (-h|--help)
             usage
-            exit 0
+            exit ${ERR_SUCCESS}
             ;;
         (-k|--keep)
             if ! test $2 -gt 0 2>/dev/null; then
                 log error "The $1 parameter must be a positive integer"
-                exit 129
+                exit ${ERR_KEEP_NEGATIVE}
             fi
             keep=$2
             shift 2
@@ -228,7 +235,7 @@ do
                 case $prefix in
                     ([![:alnum:]_.:\ -]*)
                         log error "The $1 parameter must be alphanumeric"
-                        exit 130
+                        exit ${ERR_PREFIX_WRONG}
                         ;;
                 esac
                 prefix="${prefix#?}"
@@ -260,7 +267,7 @@ done
 
 if [ $# -eq 0 ] ; then
     log error "The filesystem argument list is empty"
-    exit 133
+    exit ${ERR_FS_MISSING}
 fi
 
 # count the number of times '//' appears on the command line
@@ -272,7 +279,7 @@ done
 
 if [ $# -gt 1 -a $slashies -gt 0 ] ; then
     log error "The // must be the only argument if it is given"
-    exit 134
+    exit ${ERR_FS_SLASHIES}
 fi
 
 snapname=${prefix}_${label}-$(date +%F-%H%M)
@@ -294,7 +301,7 @@ do
     printf "%s\n" "${btrfs_list[@]}" | grep -F -f - -q <(echo ${i})
     if [ $? -ne 0 ] ; then
         log err "It appears that '${i}' is not a BTRFS filesystem!"
-        exit 135
+        exit ${ERR_FS_NO_BTRFS}
     fi
 
     if [ ! -d "${i}/.btrfs" ] ; then

--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -298,7 +298,7 @@ log info "Doing snapshots of $fs_list"
 
 for i in $fs_list
 do
-    printf "%s\n" "${btrfs_list[@]}" | grep -F -f - -q <(echo ${i})
+    printf "%s\n" "${btrfs_list[@]}" | grep -F -f - -q -x <(echo ${i})
     if [ $? -ne 0 ] ; then
         log err "It appears that '${i}' is not a BTRFS filesystem!"
         exit ${ERR_FS_NO_BTRFS}

--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -18,7 +18,19 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
+ERR_SUCCESS=0
+ERR_STDIN_EMPTY=1
+ERR_GETOPT_FAILED=128
+ERR_KEEP_NEGATIVE=129
+ERR_PREFIX_WRONG=130
+ERR_FS_MISSING=133
+ERR_FS_SLASHIES=134
+ERR_FS_NO_BTRFS=135
+
+trap argsp_cmdline_exit_handler SIGUSR1
+
 # set defaults
+argsp_cmdline_exit="${ERR_SUCCESS}"
 debug=''
 dry_run=''
 keep=''
@@ -28,15 +40,6 @@ use_syslog=''
 verbose=''
 quiet=''
 writeable='-r'
-
-ERR_SUCCESS=0
-ERR_STDIN_EMPTY=1
-ERR_GETOPT_FAILED=128
-ERR_KEEP_NEGATIVE=129
-ERR_PREFIX_WRONG=130
-ERR_FS_MISSING=133
-ERR_FS_SLASHIES=134
-ERR_FS_NO_BTRFS=135
 
 usage()
 {
@@ -114,7 +117,8 @@ argsp_stdin_to_array()
     local -r stdin="$(cat '/dev/stdin')"
     local -a ret_val=()
 
-    while IFS= read -r line; do
+    while IFS= read -r line
+    do
         local is_blank="$(  echo "${line}" | grep --count -e '^[[:space:]]*$')"
         local is_comment="$(echo "${line}" | grep --count -e '^#')"
         local is_empty="$(  echo "${line}" | grep --count -e '^$')"
@@ -134,6 +138,142 @@ argsp_stdin_to_array()
     fi
 
     declare -p ret_val | sed -e 's/^declare -a [^=]*=//'
+}
+
+##
+# Parse and set command line arguments, posisbly aborting in case of errors or missing paths to
+# actually work with.
+#
+# @param[in] Callers need t5o forward {@code $@}!
+# return     Associative array with all options and parsed paths.
+#
+argsp_cmdline()
+{
+    declare -A ret_val
+
+    ret_val[debug]=''
+    ret_val[dry_run]=''
+    ret_val[keep]=''
+    ret_val[label]=''
+    ret_val[prefix]='btrfs-auto-snap'
+    ret_val[use_syslog]=''
+    ret_val[verbose]=''
+    ret_val[quiet]=''
+    ret_val[writeable]='-r'
+    ret_val[paths]=''
+
+    while [ $# -gt 0 ]
+    do
+        case "$1" in
+            (-d|--debug)
+                ret_val[debug]=1
+                ret_val[quiet]=''
+                ret_val[verbose]=1
+                shift 1
+            ;;
+            (-g|--syslog)
+	        ret_val[use_syslog]=1
+		shift 1
+            ;;
+            (-h|--help)
+                usage
+                argsp_cmdline_exit=${ERR_SUCCESS}
+		kill -SIGUSR1 $$
+            ;;
+            (-k|--keep)
+                if ! test $2 -gt 0 2>/dev/null
+	        then
+                    log error "The $1 parameter must be a positive integer."
+                    argsp_cmdline_exit=${ERR_KEEP_NEGATIVE}
+		    kill -SIGUSR1 $$
+                fi
+                ret_val[keep]=$2
+                shift 2
+            ;;
+            (-l|--label)
+                ret_val[label]="$2"
+                shift 2
+            ;;
+            (-n|--dry-run)
+                ret_val[dry_run]='echo'
+                ret_val[verbose]=1
+                log info "Doing a dry run. Not running these commands..."
+                shift 1
+            ;;
+            (-p|--prefix)
+                prefix="$2"
+                while test "${prefix}" -gt 0
+                do
+                    case $prefix in
+                        ([![:alnum:]_.:\ -]*)
+                            log error "The $1 parameter must be alphanumeric."
+                            argsp_cmdline_exit=${ERR_PREFIX_WRONG}
+			    kill -SIGUSR1 $$
+                        ;;
+                    esac
+                    prefix="${prefix#?}"
+                done
+
+		ret_val[prefix]="$2"
+                shift 2
+            ;;
+            (-q|--quiet)
+                ret_val[debug]=''
+                ret_val[quiet]=1
+                ret_val[verbose]=''
+                shift 1
+            ;;
+            (-v|--verbose)
+                ret_val[quiet]=''
+                ret_val[verbose]=1
+                shift 1
+            ;;
+            (-w|--writeable)
+                ret_val[writeable]=''
+                shift 1
+            ;;
+            (--)
+                shift 1
+                break
+            ;;
+        esac
+    done
+
+    if [ $# -eq 0 ]
+    then
+        log error "The filesystem argument list is empty."
+        argsp_cmdline_exit=${ERR_FS_MISSING}
+	kill -SIGUSR1 $$
+    fi
+
+    # Count the number of times '//' appears on the command line.
+    local slashies=0
+    for i in "$@"
+    do
+         test "$i" = '//' && slashies=$(( $slashies + 1 ))
+    done
+
+    if [ $# -gt 1 -a $slashies -gt 0 ]
+    then
+        log error "The // must be the only argument if it is given."
+        argsp_cmdline_exit=${ERR_FS_SLASHIES}
+	kill -SIGUSR1 $$
+    fi
+
+    ret_val[paths]="$@"
+    declare -p ret_val | sed -e 's/^declare -A [^=]*=//'
+}
+
+##
+# Exit with the code stored in {@code argsp_cmdline_exit}.
+#
+# The corresponding parser function needs to be called as a subshell to be able to process the
+# returned list of paths to work with. So exit within that function doesn't work easily, which is
+# worked around by using a special global variable and {@code kill} with {@code trap}.
+#
+argsp_cmdline_exit_handler()
+{
+    exit ${argsp_cmdline_exit}
 }
 
 ##
@@ -191,96 +331,19 @@ getopt=$(getopt \
     -- "$@" ) \
     || exit ${ERR_GETOPT_FAILED}
 
-eval set -- "$getopt"
+eval set -- "${getopt}"
+cmdline="$(argsp_cmdline "$@")"
+eval "declare -A cmdline=${cmdline}"
 
-while [ $# -gt 0 ]
-do
-    case "$1" in
-        (-d|--debug)
-            debug=1
-            quiet=''
-            verbose=1
-            shift 1
-            ;;
-        (-g|--syslog)
-            use_syslog=1
-            shift 1
-            ;;
-        (-h|--help)
-            usage
-            exit ${ERR_SUCCESS}
-            ;;
-        (-k|--keep)
-            if ! test $2 -gt 0 2>/dev/null; then
-                log error "The $1 parameter must be a positive integer"
-                exit ${ERR_KEEP_NEGATIVE}
-            fi
-            keep=$2
-            shift 2
-            ;;
-        (-l|--label)
-            label="$2"
-            shift 2
-            ;;
-        (-n|--dry-run)
-            dry_run='echo'
-            verbose=1
-            log info "Doing a dry run. Not running these commands..."
-            shift 1
-            ;;
-        (-p|--prefix)
-            prefix="$2"
-            while test "${prefix}" -gt 0
-            do
-                case $prefix in
-                    ([![:alnum:]_.:\ -]*)
-                        log error "The $1 parameter must be alphanumeric"
-                        exit ${ERR_PREFIX_WRONG}
-                        ;;
-                esac
-                prefix="${prefix#?}"
-            done
-            prefix="$2"
-            shift 2
-            ;;
-        (-q|--quiet)
-            debug=''
-            quiet=1
-            verbose=''
-            shift 1
-            ;;
-        (-v|--verbose)
-            quiet=''
-            verbose=1
-            shift 1
-            ;;
-        (-w|--writeable)
-            writeable=''
-            shift 1
-            ;;
-        (--)
-            shift 1
-            break
-            ;;
-    esac
-done
-
-if [ $# -eq 0 ] ; then
-    log error "The filesystem argument list is empty"
-    exit ${ERR_FS_MISSING}
-fi
-
-# count the number of times '//' appears on the command line
-slashies=0
-for i in "$@"
-do
-    test "$i" = '//' && slashies=$(( $SLASHIES + 1 ))
-done
-
-if [ $# -gt 1 -a $slashies -gt 0 ] ; then
-    log error "The // must be the only argument if it is given"
-    exit ${ERR_FS_SLASHIES}
-fi
+debug="${cmdline[debug]}"
+dry_run="${cmdline[dry_run]}"
+keep="${cmdline[keep]}"
+label="${cmdline[label]}"
+prefix="${cmdline[prefix]}"
+use_syslog="${cmdline[use_syslog]}"
+verbose="${cmdline[verbose]}"
+quiet="${cmdline[quiet]}"
+writeable="${cmdline[writable]}"
 
 snapname=${prefix}_${label}-$(date +%F-%H%M)
 snapglob=".btrfs/${prefix}_${label}????????????????"
@@ -288,10 +351,11 @@ snapglob=".btrfs/${prefix}_${label}????????????????"
 btrfs_list=$(grep btrfs /proc/mounts | awk '{print $2}' | btrfs_subvols_calc)
 eval "declare -a btrfs_list=${btrfs_list}"
 
-if [ "$1" = '//' ] ; then
+if [ "${cmdline[paths]}" = '//' ]
+then
     fs_list="${btrfs_list[@]}"
 else
-    fs_list="$@"
+    fs_list="${cmdline[paths]}"
 fi
 
 log info "Doing snapshots of $fs_list"
@@ -318,7 +382,7 @@ do
 done
 
 if [ ! -z "${keep}" ] ; then
-    log info "Destroying all but the newest $keep snapshots"
+    log info "Destroying all but the newest ${keep} snapshots"
 
     for i in $fs_list
     do
@@ -327,7 +391,7 @@ if [ ! -z "${keep}" ] ; then
 	paths="$(echo "${snaps}" | sort -r -n -k 4 | awk '{print $NF}')"
 	paths="$(echo "${paths}" | sed  -r 's!^[^/]+/.btrfs/!.btrfs/!')"
 
-	while IFS= read j
+	while IFS= read -r j
         do
             if [ ! -z "${j#$snapglob}" ] ; then
                 continue

--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -29,6 +29,8 @@ verbose=''
 quiet=''
 writeable='-r'
 
+ARGSP_ERR_STDIN_EMPTY=1
+
 usage()
 {
     echo "Usage: $0 [options] [-l label] <'//' | name [name...]>
@@ -42,7 +44,7 @@ usage()
     -q, --quiet         Suppress warning and notices on STDOUT
     -v, --verbose       Print info messages
     -w, --writeable     Create writeable snapshots instead of read-only
-    name            Filesystem name(s), or '//' for all filesystems
+    name                Filesystem name(s), or '//' for all filesystems
 "
 }
 
@@ -87,6 +89,91 @@ log()
             echo $* 1>&2
             ;;
     esac
+}
+
+##
+# {@code STDIN} can only be consumed once, so read and return it here for later processing.
+#
+# The current approach is to have one argument per line, so we are iterating all of those already,
+# remove empty lines, comments etc. and are able to check if anything was read at all in the end. If
+# not, this is most likely an error, as it doesn't make much sense to explicitly call us, so the
+# script is aborted.
+#
+# @return {@code [0]="..." [1]="..." [...]}
+# @see <a href="https://stackoverflow.com/a/16843375/2055163">How to return an array in bash without using globals?</a>
+#
+argsp_stdin_to_array()
+{
+  local -r stdin="$(cat '/dev/stdin')"
+  local -a ret_val=()
+
+  while IFS= read -r line; do
+    local is_blank="$(  echo "${line}" | grep --count -e '^[[:space:]]*$')"
+    local is_comment="$(echo "${line}" | grep --count -e '^#')"
+    local is_empty="$(  echo "${line}" | grep --count -e '^$')"
+
+    if [ "${is_blank}" = '1' ] || [ "${is_comment}" = '1' ] || [ "${is_empty}" = '1' ]
+    then
+      continue
+    fi
+
+    ret_val+=(${line})
+  done <<< "${stdin}"
+
+  if [ ${#ret_val[@]} -eq 0 ]
+  then
+    echo 'No arguments given using STDIN.' >&2
+    exit ${ARGSP_ERR_STDIN_EMPTY}
+  fi
+
+  declare -p ret_val | sed -e 's/^declare -a [^=]*=//'
+}
+
+##
+# Calculate all BTRFS subvolumes based on all mounted BTRFS file systems.
+#
+# "zfs-auto-snapshot" is not only able to snapshot all pools, but as well all individual datasets
+# when using "//" as path. This function actually allows the same approach by not only looking at
+# mountpounts for BTRFS file systems, but their contained subvolumes as well. By default, each and
+# every subvolume simply gets a ".btrfs" directory to take snapshots and snapshots themself are of
+# course excluded here.
+#
+# @stdin  BTRFS file systems of interest, one per line.
+# @return All subvolumes, one per line.
+#
+btrfs_subvols_calc()
+{
+    local -a ret_val=()
+    local -r array_txt="$(argsp_stdin_to_array)"
+    eval "declare -a mps=${array_txt}"
+
+    for mp in "${mps[@]}"
+    do
+        # The mountpoint itself obviously is a subvolume of interest as well already.
+        ret_val+=(${mp})
+
+        local subvols="$(btrfs subvolume list "${mp}" | awk '{print $9}')"
+
+        # Subvolumes seem to have no parent UUID, while snapshots are "readonly" most likely. So
+	# check for these attributes, which seems easier than to exclude all currently available
+        # snapshots by their paths. That output doesn't include leading slashes, their common
+	# directory might change its name etc.
+        while IFS= read -r subvol
+        do
+            local abs_path="$(echo ${mp}/${subvol} | sed -r 's!^//!/!')"
+            local show="$(btrfs subvolume show "${abs_path}")"
+	    local sp='[[:space:]]+'
+            local no_parent_uuid="$(echo "${show}" | grep --count -E "^${sp}Parent UUID:${sp}-$")"
+            local is_read_only="$(  echo "${show}" | grep --count -E "^${sp}Flags:${sp}readonly$")"
+
+            if [ "${no_parent_uuid}" = '1' ] && [ "${is_read_only}" = '0' ]
+            then
+                ret_val+=(${abs_path})
+            fi
+        done <<< "${subvols}"
+    done
+
+    declare -p ret_val | sed -e 's/^declare -a [^=]*=//'
 }
 
 getopt=$(getopt \
@@ -191,10 +278,11 @@ fi
 snapname=${prefix}_${label}-$(date +%F-%H%M)
 snapglob=".btrfs/${prefix}_${label}????????????????"
 
-btrfs_list=$(grep btrfs /proc/mounts | awk '{print $2}')
+btrfs_list=$(grep btrfs /proc/mounts | awk '{print $2}' | btrfs_subvols_calc)
+eval "declare -a btrfs_list=${btrfs_list}"
 
 if [ "$1" = '//' ] ; then
-    fs_list=$btrfs_list
+    fs_list="${btrfs_list[@]}"
 else
     fs_list="$@"
 fi
@@ -203,19 +291,23 @@ log info "Doing snapshots of $fs_list"
 
 for i in $fs_list
 do
-    echo "$btrfs_list" | grep -F -f - -q <(echo ${i})
+    printf "%s\n" "${btrfs_list[@]}" | grep -F -f - -q <(echo ${i})
     if [ $? -ne 0 ] ; then
-        log err "It appears that $i is not a BTRFS filesystem"
+        log err "It appears that '${i}' is not a BTRFS filesystem!"
         exit 135
     fi
 
     if [ ! -d "${i}/.btrfs" ] ; then
-        ${dry_run} mkdir ${i}/.btrfs
+        ${dry_run} mkdir "${i}/.btrfs"
     fi
 
+    # TODO Creating snapshots too frequently so that names overlap with an existing one, result in
+    # some error message about read-only file system, not mentioning the actual snapshot itself at
+    # all. Is bit difficult to understand when happening especially during tests, so might check if
+    # the desired snapshot exists already.
     log notice $( ${dry_run} btrfs subvolume snapshot \
-        ${writeable} ${i} \
-        ${i}/.btrfs/${snapname} )
+        ${writeable} "${i}" \
+        "${i%/}/.btrfs/${snapname}" )
 done
 
 if [ ! -z "${keep}" ] ; then
@@ -223,17 +315,22 @@ if [ ! -z "${keep}" ] ; then
 
     for i in $fs_list
     do
-        btrfs subvolume list -g -s --sort=gen $i | \
-        sort -r -n -k 4 | awk '{print $NF}' | while read j
+        snaps="$(btrfs subvolume list -g -o -s --sort=gen "${i}")"
+	paths="$(echo "${snaps}" | sort -r -n -k 4 | awk '{print $NF}')"
+	paths="$(echo "${paths}" | sed  -r 's!^[^/]+/.btrfs/!.btrfs/!')"
+
+	while IFS= read j
         do
-            if [ -z "${j#$snapglob}" ] ; then
-                keep=$(( $keep - 1 ))
-                if [ $keep -lt 0 ] ; then
-                    log notice $( ${dry_run} btrfs subvolume \
-                        delete -c ${i}/${j} )
-                fi
+            if [ ! -z "${j#$snapglob}" ] ; then
+                continue
             fi
-        done
+            
+	    keep=$(( $keep - 1 ))
+            if [ $keep -lt 0 ] ; then
+                log notice $( ${dry_run} btrfs subvolume \
+                    delete -c ${i}/${j} )
+            fi
+	done <<< "${paths}"
     done
 fi
 

--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -187,21 +187,22 @@ argsp_cmdline()
                 shift 1
             ;;
             (-g|--syslog)
-	        ret_val[use_syslog]=1
-		shift 1
+                ret_val[use_syslog]=1
+                shift 1
             ;;
             (-h|--help)
                 usage
                 argsp_cmdline_exit=${ERR_SUCCESS}
-		kill -SIGUSR1 $$
+                kill -SIGUSR1 $$
             ;;
             (-k|--keep)
                 if ! test $2 -gt 0 2>/dev/null
-	        then
+                then
                     log error "The $1 parameter must be a positive integer."
                     argsp_cmdline_exit=${ERR_KEEP_NEGATIVE}
-		    kill -SIGUSR1 $$
+                    kill -SIGUSR1 $$
                 fi
+
                 ret_val[keep]=$2
                 shift 2
             ;;
@@ -223,13 +224,13 @@ argsp_cmdline()
                         ([![:alnum:]_.:\ -]*)
                             log error "The $1 parameter must be alphanumeric."
                             argsp_cmdline_exit=${ERR_PREFIX_WRONG}
-			    kill -SIGUSR1 $$
+                            kill -SIGUSR1 $$
                         ;;
                     esac
                     prefix="${prefix#?}"
                 done
 
-		ret_val[prefix]="$2"
+                ret_val[prefix]="$2"
                 shift 2
             ;;
             (-q|--quiet)
@@ -258,7 +259,7 @@ argsp_cmdline()
     then
         log error "The filesystem argument list is empty."
         argsp_cmdline_exit=${ERR_FS_MISSING}
-	kill -SIGUSR1 $$
+        kill -SIGUSR1 $$
     fi
 
     # Count the number of times '//' appears on the command line.
@@ -272,7 +273,7 @@ argsp_cmdline()
     then
         log error "The // must be the only argument if it is given."
         argsp_cmdline_exit=${ERR_FS_SLASHIES}
-	kill -SIGUSR1 $$
+        kill -SIGUSR1 $$
     fi
 
     ret_val[paths]="$@"
@@ -317,14 +318,14 @@ btrfs_subvols_calc()
         local subvols="$(btrfs subvolume list "${mp}" | awk '{print $9}')"
 
         # Subvolumes seem to have no parent UUID, while snapshots are "readonly" most likely. So
-	# check for these attributes, which seems easier than to exclude all currently available
+        # check for these attributes, which seems easier than to exclude all currently available
         # snapshots by their paths. That output doesn't include leading slashes, their common
-	# directory might change its name etc.
+        # directory might change its name etc.
         while IFS= read -r subvol
         do
             local abs_path="$(echo ${mp}/${subvol} | sed -r 's!^//!/!')"
             local show="$(btrfs subvolume show "${abs_path}")"
-	    local sp='[[:space:]]+'
+            local sp='[[:space:]]+'
             local no_parent_uuid="$(echo "${show}" | grep --count -E "^${sp}Parent UUID:${sp}-$")"
             local is_read_only="$(  echo "${show}" | grep --count -E "^${sp}Flags:${sp}readonly$")"
 
@@ -353,19 +354,19 @@ btrfs_snaps_do()
     do
         printf "%s\n" "${btrfs_list[@]}" | grep -F -f - -q -x <(echo ${i})
         if [ $? -ne 0 ]
-	then
+        then
             log err "It appears that '${i}' is not a BTRFS filesystem!"
             exit ${ERR_FS_NO_BTRFS}
         fi
 
         if [ ! -d "${i}/.btrfs" ]
-	then
+        then
             ${dry_run} mkdir "${i}/.btrfs"
         fi
 
         # TODO Creating snapshots too frequently so that names overlap with an existing one, result
         # in some error message about read-only file system, not mentioning the actual snapshot
-	# itself at all. Is bit difficult to understand when happening especially during tests, so
+        # itself at all. Is bit difficult to understand when happening especially during tests, so
         # might check if the desired snapshot exists already.
         log notice $( ${dry_run} btrfs subvolume snapshot \
             ${writeable} "${i}" \
@@ -399,13 +400,13 @@ btrfs_snaps_rm_if()
         while IFS= read -r j
         do
             if [ ! -z "${j#$snapglob}" ]
-	    then
+            then
                 continue
             fi
 
             fs_keep=$(( ${fs_keep} - 1 ))
             if [ ${fs_keep} -lt 0 ]
-	    then
+            then
                 log notice $( ${dry_run} btrfs subvolume \
                     delete -c ${i}/${j} )
             fi


### PR DESCRIPTION
After creating the changes in #6, I've tried to make the code better readable by using additional functions. This was especially of interest because of your commandline arguments and how to parse them. So I consider this pretty much a PoC of how I might handle things ion future as well... :-)

Parsing arguments is essentially the same like before, only that an [associative array](https://linuxhint.com/associative_array_bash/)  is used to return settings from the function call in the subshell. Those values are afterwards stored in the original global variables, to not need to change too much more. Though, that array could be accessed instead of the global variables I guess.

Error handling and exiting from the commandline parser is a bit difficult currently using `kill` and `trap` because of the subshell. But in my opinion it's not that bad as well.