### PR TITLE
Names of snaps have changed from using - to _.

### DIFF
--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -604,7 +604,7 @@ fi
 
 snap_name="${prefix}_${label}_$(date +%F-%H%M)"
 snap_patt='[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}-[[:digit:]]{4}'
-snap_patt="${prefix}_${label}_${snap_patt}"
+snap_patt="${prefix}_${label}[_-]${snap_patt}"
 
 btrfs_mounts="$(btrfs_mounts_calc)"
 btrfs_subvols_txt="$(echo "${btrfs_mounts}" | btrfs_subvols_calc)"


### PR DESCRIPTION
Some [commit](https://github.com/hunleyd/btrfs-auto-snapshot/commit/092e32eaf8c3c7af1338ed9ab4e4304f38c1286a#diff-b30a5b80c4710f8023192ba85ba91bfa2449930f12d49a0ab6629e8633e531b2R471) in the past changed the created snap name from containing `-` to `_` between label and date. In PR #9 I implemented cleanup of snap names [based on some regular expression](https://github.com/hunleyd/btrfs-auto-snapshot/pull/9/files#diff-b30a5b80c4710f8023192ba85ba91bfa2449930f12d49a0ab6629e8633e531b2R607), but that didn't take the change from `-` to `_` into account, so older snap names containing `_` weren't deleted anymore. This should be fixed now.