### PR TITLE
intro: set -euo pipefail

### DIFF
--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -19,7 +19,8 @@
 # this program; if not, write to the Free Software Foundation, Inc., 59 Temple
 # Place, Suite 330, Boston, MA  02111-1307  USA
 
-#set -o errexit
+set -euo pipefail
+
 #set -o functrace
 #set -o xtrace
 


### PR DESCRIPTION
Any concerns enabling it to protect ourselves from the unexpected?

I ran a basic smoke test (`btrfs-auto-snapshot /srv -l 5minutely`), that one worked. Anything you have in mind why it wouldn't?