### PR TITLE
Hardcode version, add a release script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-FILES = btrfs-auto-snapshot
+FILES = btrfs-auto-snapshot release
 
 .PHONY: lint
 lint: shfmt shellcheck

--- a/btrfs-auto-snapshot
+++ b/btrfs-auto-snapshot
@@ -24,9 +24,7 @@ set -euo pipefail
 #set -o functrace
 #set -o xtrace
 
-# Define our version. Distributions may replace it with:
-#   sed -i 's/^\(BTRFS_AUTO_SNAPSHOT_VERSION\)=.*/\1=<version>/' <file>
-BTRFS_AUTO_SNAPSHOT_VERSION=${BTRFS_AUTO_SNAPSHOT_VERSION:-unknown}
+BTRFS_AUTO_SNAPSHOT_VERSION=v2.0.4+dev
 
 # Define various error codes
 ERR_SUCCESS=0

--- a/release
+++ b/release
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+err()
+{
+    echo >&2 "Error: $*"
+    exit 1
+}
+
+log_run()
+{
+    echo >&2 "+ $*"
+    "$@"
+}
+
+git status --porcelain | grep -q "" &&
+    err "working tree is dirty, commit your changes first."
+
+[[ "$1" =~ ^v([0-9]+)\.([0-9]+)(\.([0-9]+))?(-rc([0-9]+))?$ ]] ||
+    err "arg1 accepts the following formats: v1.0 v1.0.0 v1.0-rc1 v1.0.1-rc1"
+
+git tag | grep -q "^$1$" &&
+    err "tag $1 already exists"
+
+# sanity test
+make lint
+
+log_run sed -i'' 's/^\(BTRFS_AUTO_SNAPSHOT_VERSION\)=.*/\1='"$1/" btrfs-auto-snapshot
+log_run git add btrfs-auto-snapshot
+log_run git commit -m "btrfs-auto-snapshot $1"
+
+last_tag=$(git tag | tail -1)
+{
+    echo btrfs-auto-snapshot "$1"
+    echo
+    echo Changes since "$last_tag":
+    git log --pretty=format:"- [%an] %s" "$last_tag"..HEAD
+} | log_run git tag -F - "$1"
+
+log_run sed -i'' 's/^\(BTRFS_AUTO_SNAPSHOT_VERSION\)=.*/\1='"$1+dev/" btrfs-auto-snapshot
+log_run git add btrfs-auto-snapshot
+log_run git commit -m "btrfs-auto-snapshot $1+dev"
+
+echo
+echo "You have tagged $1. Now run the following:"
+echo "  git push origin master"
+echo "  git push origin $1"


### PR DESCRIPTION
Having thought about this more, I am semi-reverting fcd4d58c5532001b6ae2e28555318818c06e79ca in favor of hardcoding the version to the binary and a release script.

```
[motiejus@mtworx:~/code/btrfs-auto-snapshot]$ ./release v3.0.0
+ sed -i s/^\(BTRFS_AUTO_SNAPSHOT_VERSION\)=.*/\1=v3.0.0/ btrfs-auto-snapshot
+ git add btrfs-auto-snapshot                           
+ git commit -m btrfs-auto-snapshot v3.0.0                                
[release-script 27c55c5] btrfs-auto-snapshot v3.0.0
1 file changed, 1 insertion(+), 1 deletion(-)
+ git tag v3.0.0
+ sed -i s/^\(BTRFS_AUTO_SNAPSHOT_VERSION\)=.*/\1=v3.0.0+dev/ btrfs-auto-snapshot
+ git add btrfs-auto-snapshot           
+ git commit -m "btrfs-auto-snapshot v3.0.0+dev"                   
[release-script 4598c6e] btrfs-auto-snapshot v3.0.0+dev
 1 file changed, 1 insertion(+), 1 deletion(-)                                                                                                       

You have tagged v3.0.0. Now run the following:
  git push origin master                 
  git push origin v3.0.0
```
